### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
 		"marked": "^0.3.3",
 		"bootbox": "~4.4.0",
-		"request": "~2.55.0",
+		"request": "~2.74.0",
 		"bootstrap": "3.3.0",
 		"phantom-html2pdf": "~0.1.3",
 		"nimble": "*",


### PR DESCRIPTION
Mango currently has a 4 vulnerable dependency paths, introducing 3 different types of known vulnerabilities.

This PR fixes vulnerable dependencies, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency, [ReDos vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.

You can see [Snyk test report](https://snyk.io/test/github/egrcc/Mango) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade other dependencies as well.

Stay Secure,
The Snyk Team
